### PR TITLE
fix: address remaining Copilot PR #33 feedback (infra Bicep)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -169,5 +169,5 @@ output communicationServiceName string = communication.outputs.communicationServ
 @description('App Insights connection string (safe — not a secret)')
 output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString
 
-@description('Static Web App deployment token — add to GitHub Secrets as AZURE_STATIC_WEB_APPS_API_TOKEN')
-output staticWebAppDeploymentToken string = staticWebApp.outputs.deploymentToken
+// staticWebAppDeploymentToken is intentionally NOT output here — see infra/modules/static-web-app.bicep
+// for the secure retrieval instructions (az staticwebapp secrets list).

--- a/infra/modules/app-service.bicep
+++ b/infra/modules/app-service.bicep
@@ -40,12 +40,6 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: Build @Microsoft.KeyVault() reference strings
-// ---------------------------------------------------------------------------
-
-var kvRef = 'https://'  // unused — refs built inline for clarity
-
-// ---------------------------------------------------------------------------
 // Web App — .NET 10 on Linux with system-assigned managed identity
 // ---------------------------------------------------------------------------
 

--- a/infra/modules/static-web-app.bicep
+++ b/infra/modules/static-web-app.bicep
@@ -40,5 +40,9 @@ resource staticWebApp 'Microsoft.Web/staticSites@2024-04-01' = {
 output defaultHostname string = staticWebApp.properties.defaultHostname
 output staticWebAppName string = staticWebApp.name
 
-@description('Deployment token for GitHub Actions — store as AZURE_STATIC_WEB_APPS_API_TOKEN secret')
-output deploymentToken string = staticWebApp.listSecrets().properties.apiKey
+// Note: The deployment token (API key) is intentionally NOT output here.
+// Exposing secrets in ARM deployment outputs stores them in Azure deployment history,
+// where they are readable by anyone with read access to the resource group.
+// Retrieve the token securely after deployment:
+//   az staticwebapp secrets list --name <app-name> --query "properties.apiKey" -o tsv
+// Then store the value as the AZURE_STATIC_WEB_APPS_API_TOKEN GitHub Actions secret.


### PR DESCRIPTION
## Summary

Addresses the 3 Copilot review comments from PR #33 not resolved before merge (infra-only, no backend/frontend changes):

- **app-service.bicep** Remove unused kvRef variable (Bicep linter warning)
- **static-web-app.bicep** Remove deploymentToken output; ARM outputs are stored in deployment history readable by anyone with resource group read access. Documents secure retrieval via az staticwebapp secrets list
- **main.bicep** Remove staticWebAppDeploymentToken from top-level outputs for the same reason

## Notes

The rate limiter feedback from PR #33 was already resolved in that PR via app.MapControllers().RequireRateLimiting(global) in Program.cs.

## Test plan

- [ ] Verify app-service.bicep has no Bicep linter warnings
- [ ] Verify az deployment outputs no longer expose the Static Web App deployment token
- [ ] Confirm token is still retrievable: az staticwebapp secrets list --name app-name --query properties.apiKey -o tsv

Generated with Claude Code