### PR TITLE
Remove Azure SDK leak from Application layer

### DIFF
--- a/backend/LegalDocSystem.API/appsettings.json
+++ b/backend/LegalDocSystem.API/appsettings.json
@@ -8,7 +8,7 @@
     "Audience": "LegalDocSystemUsers",
     "ExpiryMinutes": 1440
   },
-  "AzureStorage": {
+  "BlobStorage": {
     "ConnectionString": "",
     "ContainerName": "legal-documents"
   },

--- a/backend/LegalDocSystem.Application/Interfaces/IBlobStorageService.cs
+++ b/backend/LegalDocSystem.Application/Interfaces/IBlobStorageService.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
-using Azure.Storage.Sas;
+using LegalDocSystem.Domain.Enums;
 
 namespace LegalDocSystem.Application.Interfaces
 {
@@ -9,7 +9,7 @@ namespace LegalDocSystem.Application.Interfaces
         Task<string> UploadAsync(Stream content, string fileName, string containerName);
         Task<Stream> DownloadAsync(string fileName, string containerName);
         Task DeleteAsync(string fileName, string containerName);
-        string GetSasUri(string fileName, string containerName, BlobSasPermissions permissions, int expirationMinutes = 60);
+        string GetSasUri(string fileName, string containerName, StorageAccessPermissions permissions, int expirationMinutes = 60);
         Task<long> GetBlobSizeAsync(string fileName, string containerName);
         Task SetBlobTagsAsync(string fileName, string containerName, IDictionary<string, string> tags);
     }

--- a/backend/LegalDocSystem.Application/LegalDocSystem.Application.csproj
+++ b/backend/LegalDocSystem.Application/LegalDocSystem.Application.csproj
@@ -4,10 +4,6 @@
     <ProjectReference Include="..\LegalDocSystem.Domain\LegalDocSystem.Domain.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/LegalDocSystem.Domain/Enums/StorageAccessPermissions.cs
+++ b/backend/LegalDocSystem.Domain/Enums/StorageAccessPermissions.cs
@@ -1,0 +1,15 @@
+namespace LegalDocSystem.Domain.Enums;
+
+/// <summary>
+/// Provider-agnostic access permissions for generating pre-signed / SAS storage URLs.
+/// Map to the provider's native permission type inside the Infrastructure layer only.
+/// </summary>
+[Flags]
+public enum StorageAccessPermissions
+{
+    None   = 0,
+    Read   = 1,
+    Write  = 2,
+    Create = 4,
+    Delete = 8
+}

--- a/backend/LegalDocSystem.Infrastructure/Services/AzureBlobStorageService.cs
+++ b/backend/LegalDocSystem.Infrastructure/Services/AzureBlobStorageService.cs
@@ -1,6 +1,7 @@
 using Azure.Storage.Blobs;
 using Azure.Storage.Sas;
 using LegalDocSystem.Application.Interfaces;
+using LegalDocSystem.Domain.Enums;
 using Microsoft.Extensions.Configuration;
 
 namespace LegalDocSystem.Infrastructure.Services
@@ -11,8 +12,8 @@ namespace LegalDocSystem.Infrastructure.Services
 
         public AzureBlobStorageService(IConfiguration configuration)
         {
-            _connectionString = configuration.GetConnectionString("AzureStorage") 
-                ?? throw new ArgumentNullException("AzureStorage connection string is missing");
+            _connectionString = configuration.GetConnectionString("BlobStorage")
+                ?? throw new ArgumentNullException("BlobStorage connection string is missing");
         }
 
         public async Task<string> UploadAsync(Stream content, string fileName, string containerName)
@@ -50,7 +51,7 @@ namespace LegalDocSystem.Infrastructure.Services
             await blobClient.DeleteIfExistsAsync();
         }
 
-        public string GetSasUri(string fileName, string containerName, BlobSasPermissions permissions, int expirationMinutes = 60)
+        public string GetSasUri(string fileName, string containerName, StorageAccessPermissions permissions, int expirationMinutes = 60)
         {
             var containerClient = new BlobContainerClient(_connectionString, containerName);
             var blobClient = containerClient.GetBlobClient(fileName);
@@ -68,9 +69,19 @@ namespace LegalDocSystem.Infrastructure.Services
                 ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(expirationMinutes)
             };
 
-            sasBuilder.SetPermissions(permissions);
+            sasBuilder.SetPermissions(MapPermissions(permissions));
 
             return blobClient.GenerateSasUri(sasBuilder).ToString();
+        }
+
+        private static BlobSasPermissions MapPermissions(StorageAccessPermissions permissions)
+        {
+            BlobSasPermissions result = 0;
+            if (permissions.HasFlag(StorageAccessPermissions.Read))   result |= BlobSasPermissions.Read;
+            if (permissions.HasFlag(StorageAccessPermissions.Write))  result |= BlobSasPermissions.Write;
+            if (permissions.HasFlag(StorageAccessPermissions.Create)) result |= BlobSasPermissions.Create;
+            if (permissions.HasFlag(StorageAccessPermissions.Delete)) result |= BlobSasPermissions.Delete;
+            return result;
         }
 
         public async Task<long> GetBlobSizeAsync(string fileName, string containerName)

--- a/backend/LegalDocSystem.Infrastructure/Services/DocumentService.cs
+++ b/backend/LegalDocSystem.Infrastructure/Services/DocumentService.cs
@@ -5,7 +5,6 @@ using LegalDocSystem.Domain.Enums;
 using LegalDocSystem.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Azure.Storage.Sas;
 
 namespace LegalDocSystem.Infrastructure.Services
 {
@@ -49,7 +48,7 @@ namespace LegalDocSystem.Infrastructure.Services
             string blobName = $"{dto.ProjectId}/{Guid.NewGuid()}_{dto.FileName}";
 
             // Generate Write SAS URL
-            string uploadUrl = _blobStorageService.GetSasUri(blobName, containerName, BlobSasPermissions.Create | BlobSasPermissions.Write, 15);
+            string uploadUrl = _blobStorageService.GetSasUri(blobName, containerName, StorageAccessPermissions.Create | StorageAccessPermissions.Write, 15);
 
             // Create Pending Document Entity
             var document = new Document
@@ -142,7 +141,7 @@ namespace LegalDocSystem.Infrastructure.Services
             if (document.Project.CompanyId != user.CompanyId)
                 throw new UnauthorizedAccessException("Access to this document is not allowed");
 
-            return _blobStorageService.GetSasUri(document.BlobStoragePath, document.BlobContainerName, BlobSasPermissions.Read, 10);
+            return _blobStorageService.GetSasUri(document.BlobStoragePath, document.BlobContainerName, StorageAccessPermissions.Read, 10);
         }
 
         public async Task<DocumentDto> GetDocumentAsync(int documentId, int userId)

--- a/docs/tracking/implementation-checklist.md
+++ b/docs/tracking/implementation-checklist.md
@@ -305,7 +305,7 @@ Use this checklist to track your progress in implementing the full application.
 - [ ] Refactor code as needed
 
 ### Technical Debt
-- [ ] Fix `IBlobStorageService` interface — `GetSasUri` parameter uses `Azure.Storage.Sas.BlobSasPermissions` (Azure SDK type leaking into Application layer). Replace with a provider-agnostic `StorageAccessPermissions` enum so the interface is truly cloud-independent. See `docs/architecture/storage-provider-decision.md` for context.
+- [x] Fix `IBlobStorageService` interface — `GetSasUri` parameter now uses `StorageAccessPermissions` enum (defined in `LegalDocSystem.Domain.Enums`). Removed `Azure.Storage.Sas.BlobSasPermissions` from Application layer entirely. `AzureBlobStorageService` maps the enum to Azure's type internally. `Azure.Storage.Blobs` NuGet package removed from `LegalDocSystem.Application.csproj`. Config key renamed from `AzureStorage` → `BlobStorage` in both `appsettings.json` files. See `docs/architecture/storage-provider-decision.md` for context.
 
 ## Important Reminders
 


### PR DESCRIPTION
- Add StorageAccessPermissions [Flags] enum to Domain.Enums
- Update IBlobStorageService.GetSasUri to use StorageAccessPermissions
- Remove Azure.Storage.Blobs NuGet package from Application.csproj
- Update AzureBlobStorageService to map StorageAccessPermissions -> BlobSasPermissions internally
- Update DocumentService to use StorageAccessPermissions (no Azure imports)
- Rename config key AzureStorage -> BlobStorage in appsettings.json
- Mark technical debt item as complete in implementation-checklist.md

Application layer now has zero cloud-vendor dependencies. #cloud-provider-independence