### PR TITLE
Fix Azure deployment: startup command, Key Vault URI, DB password, SPA routing

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -105,7 +105,10 @@ jobs:
         env:
           ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_DATABASE_CONNECTION_STRING }}
 
-      - name: Remove PostgreSQL firewall rule
+      - name: Close PostgreSQL public access after migrations
+        # Always runs — re-disables public network access and removes the
+        # temporary firewall rule regardless of whether migrations succeeded.
+        # The App Service reaches the DB exclusively via the private endpoint.
         if: always()
         run: |
           az postgres flexible-server firewall-rule delete \
@@ -113,6 +116,10 @@ jobs:
             --name ${{ secrets.AZURE_POSTGRES_SERVER_NAME }} \
             --rule-name "GitHubActions-${{ github.run_id }}" \
             --yes 2>/dev/null || true
+          az postgres flexible-server update \
+            --name ${{ secrets.AZURE_POSTGRES_SERVER_NAME }} \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --public-access disabled 2>/dev/null || true
 
       # -----------------------------------------------------------------------
       # Deploy to Azure App Service

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -113,15 +113,29 @@ jobs:
         # even if the migration step failed — ensures the DB is never left publicly accessible.
         if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.skip_migrations != 'true' }}
         run: |
+          set -euo pipefail
+
           az postgres flexible-server firewall-rule delete \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --name ${{ secrets.AZURE_POSTGRES_SERVER_NAME }} \
             --rule-name "GitHubActions-${{ github.run_id }}" \
             --yes 2>/dev/null || true
+
           az postgres flexible-server update \
             --name ${{ secrets.AZURE_POSTGRES_SERVER_NAME }} \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --public-access disabled 2>/dev/null || true
+            --public-access disabled
+
+          public_access_state="$(az postgres flexible-server show \
+            --name ${{ secrets.AZURE_POSTGRES_SERVER_NAME }} \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --query 'network.publicNetworkAccess' \
+            --output tsv)"
+
+          if [ "${public_access_state}" != "Disabled" ]; then
+            echo "Expected PostgreSQL public access to be Disabled, but found '${public_access_state}'."
+            exit 1
+          fi
 
       # -----------------------------------------------------------------------
       # Deploy to Azure App Service

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -72,11 +72,14 @@ jobs:
       # EF Core migrations
       # -----------------------------------------------------------------------
       - name: Install EF Core tools
-        if: ${{ github.event.inputs.skip_migrations != 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_migrations != 'true' }}
         run: dotnet tool install --global dotnet-ef
 
       - name: Open PostgreSQL firewall for CI runner
-        if: ${{ github.event.inputs.skip_migrations != 'true' }}
+        # Only runs on manual dispatch — GitHub runners cannot reach a VNet-injected (private)
+        # PostgreSQL server on push events, so migrations are skipped and delegated to
+        # Program.cs startup migration on App Service (which is VNet-integrated).
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_migrations != 'true' }}
         run: |
           RUNNER_IP=$(curl -s https://api.ipify.org)
           echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
@@ -99,17 +102,16 @@ jobs:
             --end-ip-address $RUNNER_IP
 
       - name: Run EF Core migrations
-        if: ${{ github.event.inputs.skip_migrations != 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_migrations != 'true' }}
         working-directory: backend/LegalDocSystem.API
         run: dotnet ef database update --no-build
         env:
           ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_DATABASE_CONNECTION_STRING }}
 
       - name: Close PostgreSQL public access after migrations
-        # Always runs — re-disables public network access and removes the
-        # temporary firewall rule regardless of whether migrations succeeded.
-        # The App Service reaches the DB exclusively via the private endpoint.
-        if: always()
+        # Runs whenever the firewall was opened (workflow_dispatch + migrations not skipped),
+        # even if the migration step failed — ensures the DB is never left publicly accessible.
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.skip_migrations != 'true' }}
         run: |
           az postgres flexible-server firewall-rule delete \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \

--- a/backend/LegalDocSystem.API/Program.cs
+++ b/backend/LegalDocSystem.API/Program.cs
@@ -139,6 +139,25 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+// Apply pending EF Core migrations on startup.
+// This runs inside the VNet (App Service has VNet integration), so the DB is reachable.
+// db.Database.Migrate() is idempotent — safe to call on every startup.
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationDbContext>>();
+    try
+    {
+        db.Database.Migrate();
+        logger.LogInformation("Database migrations applied successfully");
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Failed to apply database migrations on startup");
+        throw;
+    }
+}
+
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())
 {

--- a/backend/LegalDocSystem.API/Program.cs
+++ b/backend/LegalDocSystem.API/Program.cs
@@ -152,6 +152,18 @@ if (!app.Environment.IsDevelopment())
     var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationDbContext>>();
     try
     {
+        // Acquire a PostgreSQL session-level advisory lock before running migrations.
+        // This serialises concurrent startup migrations during scale-out events —
+        // only one instance migrates at a time; others block until it completes.
+        // The lock is automatically released when this connection closes (scope disposal).
+        const long MigrationLockId = 0x4C617767617465L; // "Lawgate" in ASCII as int64
+        db.Database.OpenConnection();
+        using (var lockCmd = db.Database.GetDbConnection().CreateCommand())
+        {
+            lockCmd.CommandText = $"SELECT pg_advisory_lock({MigrationLockId})";
+            lockCmd.ExecuteNonQuery();
+        }
+        logger.LogInformation("Migration advisory lock acquired; applying pending migrations");
         db.Database.Migrate();
         logger.LogInformation("Database migrations applied successfully");
     }

--- a/backend/LegalDocSystem.API/Program.cs
+++ b/backend/LegalDocSystem.API/Program.cs
@@ -139,11 +139,15 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
-// Apply pending EF Core migrations on startup.
+// Apply pending EF Core migrations on startup in non-Development environments.
+// Development uses the dedicated migrate-and-seed block further below.
 // This runs inside the VNet (App Service has VNet integration), so the DB is reachable.
 // db.Database.Migrate() is idempotent — safe to call on every startup.
-using (var scope = app.Services.CreateScope())
+// NOTE: This app runs as a single App Service instance; scale-out migrations
+// would need an advisory lock or a dedicated migration job.
+if (!app.Environment.IsDevelopment())
 {
+    using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationDbContext>>();
     try

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/*.{css,js,ico,png,svg,woff,woff2,ttf,eot}"]
+  }
+}

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,6 +1,17 @@
 {
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/assets/*", "/*.{css,js,ico,png,svg,woff,woff2,ttf,eot}"]
+    "exclude": [
+      "/assets/*",
+      "/*.css",
+      "/*.js",
+      "/*.ico",
+      "/*.png",
+      "/*.svg",
+      "/*.woff",
+      "/*.woff2",
+      "/*.ttf",
+      "/*.eot"
+    ]
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -34,6 +34,9 @@ param existingDbServerName string = ''
 @description('PostgreSQL administrator login username for the existing server')
 param dbAdminLogin string = 'lawgate_admin'
 
+@description('Existing VNet name — set to reuse a pre-existing VNet and its subnets instead of creating a new one')
+param existingVnetName string = ''
+
 @description('Azure External ID external tenant ID — populate after running scripts/setup-external-id.ps1')
 param externalIdTenantId string = ''
 
@@ -53,7 +56,9 @@ var namePrefix = '${appName}-${environment}'
 // waiting for the Key Vault module to deploy (avoids a circular dependency)
 var keyVaultName = 'lg-kv-${take(suffix, 10)}'
 // Use environment() to avoid hardcoded cloud URLs (supports sovereign clouds)
-var keyVaultUri = 'https://${keyVaultName}.${az.environment().suffixes.keyvaultDns}/'
+// Note: az.environment().suffixes.keyvaultDns already includes the leading dot
+// (e.g. '.vault.azure.net'), so we must NOT add another dot before it.
+var keyVaultUri = 'https://${keyVaultName}${az.environment().suffixes.keyvaultDns}/'
 
 // ===========================================================================
 // Modules
@@ -82,9 +87,22 @@ module storage 'modules/storage.bicep' = {
   }
 }
 
-// --- Database --------------------------------------------------------------
-// If an existing server name is supplied, reference it (avoids quota issues);
-// otherwise create a new one via the database module.
+// --- VNet (no dependencies) -------------------------------------------------
+// Provisions the VNet first so the postgres-subnet and private DNS zone IDs
+// are available before the database module runs.
+
+module vnet 'modules/vnet.bicep' = {
+  name: 'vnet'
+  params: {
+    location: location
+    vnetName: '${namePrefix}-vnet'
+    existingVnetName: existingVnetName
+  }
+}
+
+// --- Database (depends on: vnet) --------------------------------------------
+// If an existing server name is supplied, reference it; otherwise create a new
+// VNet-injected server via the database module.
 
 var useExistingDb = existingDbServerName != ''
 
@@ -102,16 +120,6 @@ resource existingAppDb 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023
   }
 }
 
-// Ensure Azure services firewall rule exists on the existing server
-resource existingDbFirewall 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = if (useExistingDb) {
-  parent: existingDbServer
-  name: 'AllowAzureServices'
-  properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
-  }
-}
-
 var newDbServerName = '${namePrefix}-db-${take(suffix, 6)}'
 
 module database 'modules/database.bicep' = if (!useExistingDb) {
@@ -122,6 +130,9 @@ module database 'modules/database.bicep' = if (!useExistingDb) {
     administratorLogin: dbAdminLogin
     administratorLoginPassword: postgresAdminPassword
     databaseName: 'lawgate_db'
+    // VNet injection — server has no public endpoint; all traffic via private IP
+    delegatedSubnetResourceId: vnet.outputs.postgresSubnetId
+    privateDnsZoneArmResourceId: vnet.outputs.privateDnsZoneId
   }
 }
 
@@ -155,6 +166,9 @@ module appService 'modules/app-service.bicep' = {
     corsOrigin: 'https://${staticWebApp.outputs.defaultHostname}'
     externalIdTenantId: externalIdTenantId
     externalIdAudience: externalIdApiClientId
+    // VNet integration — outbound traffic from the App Service routes through
+    // this delegated subnet, enabling it to reach the PostgreSQL private endpoint
+    subnetId: vnet.outputs.appServiceSubnetId
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -106,6 +106,10 @@ module vnet 'modules/vnet.bicep' = {
 
 var useExistingDb = existingDbServerName != ''
 
+// NOTE: The existing-server path assumes the server uses private access (VNet injection).
+// This template does not create or manage firewall rules for existing servers.
+// If the existing server uses public network access, ensure an AllowAzureServices (or
+// equivalent IP-based) firewall rule is in place separately before deploying.
 resource existingDbServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' existing = if (useExistingDb) {
   name: useExistingDb ? existingDbServerName : 'placeholder'
 }

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -38,11 +38,19 @@ param jwtSecretKey = ''            // REQUIRED — set via CLI or environment
 // instead of provisioning a new one (avoids quota issues on fresh subscriptions)
 // ===========================================================================
 
-// Name of the existing PostgreSQL flexible server in the resource group
+// Name of the existing PostgreSQL flexible server in the resource group.
+// Leave empty to create a new VNet-injected server (private access mode, no public endpoint).
 param existingDbServerName = 'lawgate-prod-webapp-server'
 
 // Admin login for the existing server (auto-generated when server was first created)
 param dbAdminLogin = 'osxgosjnrg'
+
+// ===========================================================================
+// Existing VNet — reuse the pre-provisioned VNet and its subnets
+// ===========================================================================
+
+// Leave empty to create a new VNet (e.g. on a clean subscription)
+param existingVnetName = 'lawgate-prod-webappVnet'
 
 // ===========================================================================
 // External ID — populate AFTER running scripts/setup-external-id.ps1

--- a/infra/main.json
+++ b/infra/main.json
@@ -96,7 +96,7 @@
     "suffix": "[uniqueString(resourceGroup().id)]",
     "namePrefix": "[format('{0}-{1}', parameters('appName'), parameters('environment'))]",
     "keyVaultName": "[format('lg-kv-{0}', take(variables('suffix'), 10))]",
-    "keyVaultUri": "[format('https://{0}.{1}/', variables('keyVaultName'), environment().suffixes.keyvaultDns)]",
+    "keyVaultUri": "[format('https://{0}{1}/', variables('keyVaultName'), environment().suffixes.keyvaultDns)]",
     "useExistingDb": "[not(equals(parameters('existingDbServerName'), ''))]",
     "newDbServerName": "[format('{0}-db-{1}', variables('namePrefix'), take(variables('suffix'), 6))]",
     "dbServerFqdn": "[if(variables('useExistingDb'), format('{0}.postgres.database.azure.com', parameters('existingDbServerName')), format('{0}.postgres.database.azure.com', variables('newDbServerName')))]"

--- a/infra/modules/app-service.bicep
+++ b/infra/modules/app-service.bicep
@@ -22,6 +22,9 @@ param externalIdTenantId string = ''
 @description('Azure External ID API app client ID — leave empty until setup-external-id.ps1 is run')
 param externalIdAudience string = ''
 
+@description('Subnet resource ID for regional VNet integration — routes App Service outbound traffic through the VNet to reach PostgreSQL via private endpoint')
+param subnetId string = ''
+
 // ---------------------------------------------------------------------------
 // App Service Plan — Linux B1 (upgrade to P1v3 for production traffic)
 // ---------------------------------------------------------------------------
@@ -52,13 +55,23 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
+    // Regional VNet integration — routes all outbound traffic through the VNet
+    // so the app can reach PostgreSQL via its private endpoint without going over
+    // the public internet. Empty string disables it (local dev / first deploy).
+    virtualNetworkSubnetId: !empty(subnetId) ? subnetId : null
     siteConfig: {
       linuxFxVersion: 'DOTNETCORE|10.0'
+      // Explicit startup command prevents Oryx from picking the wrong DLL when
+      // the publish output contains multiple .runtimeconfig.json files
+      // (e.g. BuildHost-netcore from Roslyn/EF Core tooling).
+      appCommandLine: 'dotnet LegalDocSystem.API.dll'
       alwaysOn: true
       ftpsState: 'Disabled'
       http20Enabled: true
       minTlsVersion: '1.2'
       healthCheckPath: '/health'
+      // Route ALL outbound traffic through the VNet (not just RFC 1918 addresses)
+      vnetRouteAllEnabled: !empty(subnetId)
       appSettings: [
         // Application Insights — safe to store directly (not a secret)
         {

--- a/infra/modules/database.bicep
+++ b/infra/modules/database.bicep
@@ -34,6 +34,9 @@ param delegatedSubnetResourceId string = ''
 @description('Private DNS zone resource ID — required when delegatedSubnetResourceId is set')
 param privateDnsZoneArmResourceId string = ''
 
+// Fail fast at deployment time if the caller supplied a delegated subnet but forgot the DNS zone.
+assert delegatedSubnetRequiresPrivateDnsZone = empty(delegatedSubnetResourceId) || !empty(privateDnsZoneArmResourceId) : 'privateDnsZoneArmResourceId must be provided when delegatedSubnetResourceId is set.'
+
 // ---------------------------------------------------------------------------
 // PostgreSQL Flexible Server
 // ---------------------------------------------------------------------------

--- a/infra/modules/database.bicep
+++ b/infra/modules/database.bicep
@@ -77,7 +77,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-pr
       privateDnsZoneArmResourceId: privateDnsZoneArmResourceId
       publicNetworkAccess: 'Disabled'
     } : {
-      publicNetworkAccess: 'Disabled'
+      publicNetworkAccess: 'Enabled'
     }
   }
 }

--- a/infra/modules/database.bicep
+++ b/infra/modules/database.bicep
@@ -28,6 +28,12 @@ param skuName string = 'Standard_B1ms'
 @maxValue(35)
 param backupRetentionDays int = 7
 
+@description('Delegated subnet resource ID — required for VNet injection (private access mode). Leave empty to use public access.')
+param delegatedSubnetResourceId string = ''
+
+@description('Private DNS zone resource ID — required when delegatedSubnetResourceId is set')
+param privateDnsZoneArmResourceId string = ''
+
 // ---------------------------------------------------------------------------
 // PostgreSQL Flexible Server
 // ---------------------------------------------------------------------------
@@ -64,6 +70,15 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-pr
       startHour: 2
       startMinute: 0
     }
+    // Private access (VNet injection): server lives in the delegated subnet with no public endpoint.
+    // If subnet/DNS params are omitted the server falls back to public access — not recommended.
+    network: !empty(delegatedSubnetResourceId) ? {
+      delegatedSubnetResourceId: delegatedSubnetResourceId
+      privateDnsZoneArmResourceId: privateDnsZoneArmResourceId
+      publicNetworkAccess: 'Disabled'
+    } : {
+      publicNetworkAccess: 'Disabled'
+    }
   }
 }
 
@@ -77,20 +92,6 @@ resource applicationDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/database
   properties: {
     charset: 'UTF8'
     collation: 'en_US.utf8'
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Firewall rules
-// ---------------------------------------------------------------------------
-
-// Allow Azure services (App Service, migrations runner) — uses private routing within Azure
-resource allowAzureServices 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-12-01-preview' = {
-  parent: postgresServer
-  name: 'AllowAzureServices'
-  properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
   }
 }
 

--- a/infra/modules/vnet.bicep
+++ b/infra/modules/vnet.bicep
@@ -7,6 +7,12 @@ param vnetName string
 @description('Name of an existing VNet to reuse. Set this to skip VNet creation and reference existing subnets and DNS zone.')
 param existingVnetName string = ''
 
+@description('App Service subnet name inside the existing VNet. Only used when existingVnetName is set.')
+param existingAppServiceSubnetName string = 'lawgate-prod-webappAppSubnet'
+
+@description('PostgreSQL Flexible Server subnet name inside the existing VNet. Only used when existingVnetName is set.')
+param existingPostgresSubnetName string = 'lawgate-prod-webappDbSubnet'
+
 var useExistingVnet = existingVnetName != ''
 var resolvedVnetName = useExistingVnet ? existingVnetName : vnetName
 
@@ -79,8 +85,8 @@ resource newDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2
 
 // Subnet names differ between the existing VNet (manually provisioned) and
 // new VNets created by this module.
-var appServiceSubnetName = useExistingVnet ? 'lawgate-prod-webappAppSubnet' : 'app-service-subnet'
-var postgresSubnetName   = useExistingVnet ? 'lawgate-prod-webappDbSubnet'  : 'postgres-subnet'
+var appServiceSubnetName = useExistingVnet ? existingAppServiceSubnetName : 'app-service-subnet'
+var postgresSubnetName   = useExistingVnet ? existingPostgresSubnetName : 'postgres-subnet'
 
 // ===========================================================================
 // Outputs — built with resourceId() to avoid BCP318 on conditional resources

--- a/infra/modules/vnet.bicep
+++ b/infra/modules/vnet.bicep
@@ -1,0 +1,99 @@
+@description('Azure region — only used when creating a new VNet')
+param location string
+
+@description('Name for a new VNet — only used when existingVnetName is empty')
+param vnetName string
+
+@description('Name of an existing VNet to reuse. Set this to skip VNet creation and reference existing subnets and DNS zone.')
+param existingVnetName string = ''
+
+var useExistingVnet = existingVnetName != ''
+var resolvedVnetName = useExistingVnet ? existingVnetName : vnetName
+
+// ===========================================================================
+// NEW VNet path — only runs when existingVnetName is empty
+// Creates VNet, delegated subnets, private DNS zone, and VNet link.
+// ===========================================================================
+
+resource newVnet 'Microsoft.Network/virtualNetworks@2024-01-01' = if (!useExistingVnet) {
+  name: vnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: ['10.0.0.0/16']
+    }
+    subnets: [
+      {
+        name: 'app-service-subnet'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          delegations: [
+            {
+              name: 'app-service-delegation'
+              properties: {
+                serviceName: 'Microsoft.Web/serverFarms'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: 'postgres-subnet'
+        properties: {
+          addressPrefix: '10.0.2.0/24'
+          delegations: [
+            {
+              name: 'postgres-delegation'
+              properties: {
+                serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource newDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (!useExistingVnet) {
+  name: 'privatelink.postgres.database.azure.com'
+  location: 'global'
+}
+
+resource newDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = if (!useExistingVnet) {
+  parent: newDnsZone
+  name: '${vnetName}-postgres-link'
+  location: 'global'
+  properties: {
+    virtualNetwork: {
+      id: newVnet.id
+    }
+    registrationEnabled: false
+  }
+}
+
+// ===========================================================================
+// EXISTING VNet path — no resources created; subnet names map to what the
+// existing manually-provisioned VNet (lawgate-prod-webappVnet) uses.
+// ===========================================================================
+
+// Subnet names differ between the existing VNet (manually provisioned) and
+// new VNets created by this module.
+var appServiceSubnetName = useExistingVnet ? 'lawgate-prod-webappAppSubnet' : 'app-service-subnet'
+var postgresSubnetName   = useExistingVnet ? 'lawgate-prod-webappDbSubnet'  : 'postgres-subnet'
+
+// ===========================================================================
+// Outputs — built with resourceId() to avoid BCP318 on conditional resources
+// ===========================================================================
+
+@description('Subnet resource ID for App Service regional VNet integration')
+output appServiceSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', resolvedVnetName, appServiceSubnetName)
+
+@description('Subnet resource ID for PostgreSQL Flexible Server VNet injection')
+output postgresSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', resolvedVnetName, postgresSubnetName)
+
+@description('Private DNS zone resource ID for privatelink.postgres.database.azure.com')
+output privateDnsZoneId string = resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.database.azure.com')
+
+@description('VNet resource ID')
+output vnetId string = resourceId('Microsoft.Network/virtualNetworks', resolvedVnetName)

--- a/infra/scripts/deploy.ps1
+++ b/infra/scripts/deploy.ps1
@@ -57,8 +57,9 @@ param(
     [Parameter(Mandatory)]
     [string] $ResourceGroup,
 
-    [Parameter(Mandatory)]
-    [string] $Location,
+    # Only required when the resource group does not yet exist.
+    # Resource locations (Central India, East Asia, etc.) come from main.bicepparam.
+    [string] $Location = '',
 
     [string] $Subscription = '',
 
@@ -123,6 +124,20 @@ function Get-SecureStringPlainText([System.Security.SecureString]$ss) {
     finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
 }
 
+# Try to read a secret from the Key Vault in the given resource group.
+# Returns $null if the vault doesn't exist yet or the secret is not found.
+function Read-SecretFromKeyVault([string]$rg, [string]$secretName) {
+    $savedEAP = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    $kvName = az keyvault list --resource-group $rg --query '[0].name' -o tsv 2>$null
+    $ErrorActionPreference = $savedEAP
+    if (-not $kvName) { return $null }
+    $savedEAP2 = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    $value = az keyvault secret show --vault-name $kvName --name $secretName --query 'value' -o tsv 2>$null
+    $ErrorActionPreference = $savedEAP2
+    if ($value) { return $value }
+    return $null
+}
+
 # ---------------------------------------------------------------------------
 # Step 1 - Prerequisites
 # ---------------------------------------------------------------------------
@@ -176,6 +191,7 @@ Write-Step 3 "Resource group: $ResourceGroup"
 
 $rgExists = az group exists --name $ResourceGroup | ConvertFrom-Json
 if (-not $rgExists) {
+    if (-not $Location) { throw "-Location is required when the resource group does not yet exist." }
     Write-Host "  Creating resource group..."
     az group create --name $ResourceGroup --location $Location | Out-Null
     Write-Host "  Created: $ResourceGroup in $Location"
@@ -190,14 +206,31 @@ if (-not $rgExists) {
 if (-not $SkipBicep) {
     Write-Step 4 "Bicep infrastructure deployment"
 
-    # Collect secure params interactively if not supplied
+    # Resolve secure params: CLI flag > Key Vault > interactive prompt.
+    # On re-runs both values already exist in Key Vault so no prompt appears.
     if (-not $PostgresPassword) {
-        $pgSecure  = Read-Host "  Enter PostgreSQL admin password" -AsSecureString
-        $PostgresPassword = Get-SecureStringPlainText $pgSecure
+        Write-Host "  Looking up PostgreSQL password from Key Vault..."
+        $dbConnStr = Read-SecretFromKeyVault $ResourceGroup 'DatabaseConnectionString'
+        if ($dbConnStr) {
+            # Parse Password=... from the Npgsql connection string
+            $PostgresPassword = ([regex]'(?i)Password=([^;]+)').Match($dbConnStr).Groups[1].Value
+        }
+        if (-not $PostgresPassword) {
+            $pgSecure = Read-Host "  Enter PostgreSQL admin password" -AsSecureString
+            $PostgresPassword = Get-SecureStringPlainText $pgSecure
+        } else {
+            Write-Host "  PostgreSQL password read from Key Vault" -ForegroundColor DarkGray
+        }
     }
     if (-not $JwtSecret) {
-        $jwtSecure = Read-Host "  Enter JWT secret key (min 32 chars)" -AsSecureString
-        $JwtSecret = Get-SecureStringPlainText $jwtSecure
+        Write-Host "  Looking up JWT secret from Key Vault..."
+        $JwtSecret = Read-SecretFromKeyVault $ResourceGroup 'JwtSecretKey'
+        if (-not $JwtSecret) {
+            $jwtSecure = Read-Host "  Enter JWT secret key (min 32 chars)" -AsSecureString
+            $JwtSecret = Get-SecureStringPlainText $jwtSecure
+        } else {
+            Write-Host "  JWT secret read from Key Vault" -ForegroundColor DarkGray
+        }
     }
     if ($JwtSecret.Length -lt 32) {
         throw "JWT secret must be at least 32 characters"
@@ -274,17 +307,33 @@ if (-not $SkipBicep) {
 # ---------------------------------------------------------------------------
 
 if (-not $SkipMigrations) {
-    Write-Step 5 "Opening PostgreSQL firewall for local migrations"
-
-    $myIp = (Invoke-RestMethod 'https://api.ipify.org?format=json').ip
-    Write-Host "  Local IP: $myIp"
-
-    # Find the PostgreSQL server in the resource group
+    # Detect whether the PostgreSQL server uses VNet injection (private access).
+    # VNet-injected servers have no public DNS entry — the FQDN only resolves
+    # inside the VNet. Migrations run automatically on App Service startup instead.
     $pgServer = az postgres flexible-server list `
         --resource-group $ResourceGroup `
-        --query '[0].name' -o tsv
+        --query '[0].name' -o tsv 2>$null
 
-    if (-not $pgServer) { throw "No PostgreSQL server found in $ResourceGroup" }
+    $isVnetInjected = $false
+    if ($pgServer) {
+        $delegatedSubnet = az postgres flexible-server show `
+            --name $pgServer --resource-group $ResourceGroup `
+            --query 'network.delegatedSubnetResourceId' -o tsv 2>$null
+        $isVnetInjected = -not [string]::IsNullOrEmpty($delegatedSubnet)
+    }
+
+    if ($isVnetInjected) {
+        Write-Step "5+6" "Skipping local migrations — VNet-injected server"
+        Write-Host "  Server '$pgServer' uses private access (VNet injection)." -ForegroundColor DarkYellow
+        Write-Host "  Its FQDN has no public DNS entry and cannot be reached from this machine." -ForegroundColor DarkYellow
+        Write-Host "  Migrations will be applied automatically on App Service startup via Program.cs." -ForegroundColor DarkYellow
+    } else {
+        Write-Step 5 "Opening PostgreSQL firewall for local migrations"
+
+        $myIp = (Invoke-RestMethod 'https://api.ipify.org?format=json').ip
+        Write-Host "  Local IP: $myIp"
+
+        # $pgServer already resolved above
 
     # Ensure the server is started (it may be stopped)
     $pgState = az postgres flexible-server show --name $pgServer --resource-group $ResourceGroup --query 'state' -o tsv 2>$null
@@ -363,6 +412,7 @@ if (-not $SkipMigrations) {
         --rule-name "LocalMigrations-$(Get-Date -Format 'yyyyMMddHHmm')" `
         --yes 2>$null
     Write-Host "  Temporary firewall rule removed"
+    } # end non-VNet-injected migrations block
 } else {
     Write-Step "5+6" "Skipping migrations (--SkipMigrations)"
 }
@@ -426,7 +476,11 @@ if (-not $SkipFrontend) {
         $env:VITE_API_URL = "$($script:ApiUrl)/api"
 
         Write-Host "  Building React app (production)..."
+        $savedEAP8 = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
         npm run build 2>&1 | Where-Object { $_ -match 'error|warning|built in' }
+        $buildExit = $LASTEXITCODE
+        $ErrorActionPreference = $savedEAP8
+        if ($buildExit -ne 0) { throw "Frontend build failed (exit $buildExit)" }
 
         # Static Web Apps are deployed via the deployment token from Bicep.
         # If the Static Web Apps CLI is present, use it; otherwise print instructions.

--- a/infra/scripts/deploy.ps1
+++ b/infra/scripts/deploy.ps1
@@ -126,10 +126,27 @@ function Get-SecureStringPlainText([System.Security.SecureString]$ss) {
 
 # Try to read a secret from the Key Vault in the given resource group.
 # Returns $null if the vault doesn't exist yet or the secret is not found.
-function Read-SecretFromKeyVault([string]$rg, [string]$secretName) {
-    $savedEAP = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-    $kvName = az keyvault list --resource-group $rg --query '[0].name' -o tsv 2>$null
-    $ErrorActionPreference = $savedEAP
+function Read-SecretFromKeyVault([string]$rg, [string]$secretName, [string]$keyVaultName = $null) {
+    $kvName = $keyVaultName
+
+    if (-not $kvName) {
+        $savedEAP = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+        $keyVaultNames = @(az keyvault list --resource-group $rg --query '[].name' -o tsv 2>$null)
+        $ErrorActionPreference = $savedEAP
+
+        if (-not $keyVaultNames -or $keyVaultNames.Count -eq 0) { return $null }
+
+        # Prefer vaults matching the project naming convention (lg-kv-*)
+        $matchingNames = @($keyVaultNames | Where-Object { $_ -like 'lg-kv-*' })
+        $candidates = if ($matchingNames.Count -gt 0) { $matchingNames } else { $keyVaultNames }
+
+        if ($candidates.Count -gt 1) {
+            throw "Multiple Key Vaults found in resource group '$rg'. Pass the expected Key Vault name explicitly to Read-SecretFromKeyVault."
+        }
+
+        $kvName = $candidates[0]
+    }
+
     if (-not $kvName) { return $null }
     $savedEAP2 = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
     $value = az keyvault secret show --vault-name $kvName --name $secretName --query 'value' -o tsv 2>$null
@@ -313,6 +330,10 @@ if (-not $SkipMigrations) {
     $pgServer = az postgres flexible-server list `
         --resource-group $ResourceGroup `
         --query '[0].name' -o tsv 2>$null
+
+    if ([string]::IsNullOrWhiteSpace($pgServer)) {
+        throw "No Azure Database for PostgreSQL Flexible Server was found in resource group '$ResourceGroup'. Cannot continue with firewall configuration or migrations."
+    }
 
     $isVnetInjected = $false
     if ($pgServer) {

--- a/infra/scripts/deploy.ps1
+++ b/infra/scripts/deploy.ps1
@@ -75,6 +75,15 @@ param(
     # convention: "${appName}-${environment}-frontend" (e.g. lawgate-prod-frontend).
     [string] $StaticWebAppName = '',
 
+    # Explicit PostgreSQL Flexible Server name — avoids picking an arbitrary server when
+    # multiple exist in the resource group. Required when the resource group contains
+    # more than one Flexible Server.
+    [string] $PostgresServerName = '',
+
+    # Explicit Key Vault name — avoids ambiguity when the resource group contains more
+    # than one vault. If omitted, the script filters by the 'lg-kv-*' naming convention.
+    [string] $KeyVaultName = '',
+
     [switch] $SkipBicep,
     [switch] $SkipMigrations,
     [switch] $SkipBackend,
@@ -141,7 +150,7 @@ function Read-SecretFromKeyVault([string]$rg, [string]$secretName, [string]$keyV
         $candidates = if ($matchingNames.Count -gt 0) { $matchingNames } else { $keyVaultNames }
 
         if ($candidates.Count -gt 1) {
-            throw "Multiple Key Vaults found in resource group '$rg'. Pass the expected Key Vault name explicitly to Read-SecretFromKeyVault."
+            throw "Multiple Key Vaults found in resource group '$rg'. The deployment script cannot determine which vault to use automatically. Ensure the resource group contains only the intended Key Vault, or re-run with -KeyVaultName to specify the vault explicitly."
         }
 
         $kvName = $candidates[0]
@@ -227,7 +236,7 @@ if (-not $SkipBicep) {
     # On re-runs both values already exist in Key Vault so no prompt appears.
     if (-not $PostgresPassword) {
         Write-Host "  Looking up PostgreSQL password from Key Vault..."
-        $dbConnStr = Read-SecretFromKeyVault $ResourceGroup 'DatabaseConnectionString'
+        $dbConnStr = Read-SecretFromKeyVault $ResourceGroup 'DatabaseConnectionString' $KeyVaultName
         if ($dbConnStr) {
             # Parse Password=... from the Npgsql connection string
             $PostgresPassword = ([regex]'(?i)Password=([^;]+)').Match($dbConnStr).Groups[1].Value
@@ -241,7 +250,7 @@ if (-not $SkipBicep) {
     }
     if (-not $JwtSecret) {
         Write-Host "  Looking up JWT secret from Key Vault..."
-        $JwtSecret = Read-SecretFromKeyVault $ResourceGroup 'JwtSecretKey'
+        $JwtSecret = Read-SecretFromKeyVault $ResourceGroup 'JwtSecretKey' $KeyVaultName
         if (-not $JwtSecret) {
             $jwtSecure = Read-Host "  Enter JWT secret key (min 32 chars)" -AsSecureString
             $JwtSecret = Get-SecureStringPlainText $jwtSecure
@@ -327,12 +336,23 @@ if (-not $SkipMigrations) {
     # Detect whether the PostgreSQL server uses VNet injection (private access).
     # VNet-injected servers have no public DNS entry — the FQDN only resolves
     # inside the VNet. Migrations run automatically on App Service startup instead.
-    $pgServer = az postgres flexible-server list `
-        --resource-group $ResourceGroup `
-        --query '[0].name' -o tsv 2>$null
+    $pgServer = if ($PostgresServerName) {
+        $PostgresServerName
+    } else {
+        $name = az postgres flexible-server list `
+            --resource-group $ResourceGroup `
+            --query '[0].name' -o tsv 2>$null
 
-    if ([string]::IsNullOrWhiteSpace($pgServer)) {
-        throw "No Azure Database for PostgreSQL Flexible Server was found in resource group '$ResourceGroup'. Cannot continue with firewall configuration or migrations."
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            throw "No Azure Database for PostgreSQL Flexible Server was found in resource group '$ResourceGroup'. Cannot continue with firewall configuration or migrations."
+        }
+
+        # Warn when multiple servers exist — the first was chosen non-deterministically.
+        $serverCount = @(az postgres flexible-server list --resource-group $ResourceGroup --query '[].name' -o tsv 2>$null).Count
+        if ($serverCount -gt 1) {
+            Write-Warning "Multiple PostgreSQL Flexible Servers found in '$ResourceGroup'. Using '$name'. Pass -PostgresServerName to select explicitly."
+        }
+        $name
     }
 
     $isVnetInjected = $false
@@ -377,10 +397,11 @@ if (-not $SkipMigrations) {
     }
 
     $savedEAP3 = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    $firewallRuleName = "LocalMigrations-$(Get-Date -Format 'yyyyMMddHHmm')"
     az postgres flexible-server firewall-rule create `
         --resource-group $ResourceGroup `
         --name $pgServer `
-        --rule-name "LocalMigrations-$(Get-Date -Format 'yyyyMMddHHmm')" `
+        --rule-name $firewallRuleName `
         --start-ip-address $myIp `
         --end-ip-address $myIp 2>&1 | Out-Null
     $ErrorActionPreference = $savedEAP3
@@ -426,11 +447,11 @@ if (-not $SkipMigrations) {
         Remove-Item Env:ConnectionStrings__DefaultConnection -ErrorAction SilentlyContinue
     }
 
-    # Remove the temporary firewall rule
+    # Remove the temporary firewall rule using the same name captured at creation.
     az postgres flexible-server firewall-rule delete `
         --resource-group $ResourceGroup `
         --name $pgServer `
-        --rule-name "LocalMigrations-$(Get-Date -Format 'yyyyMMddHHmm')" `
+        --rule-name $firewallRuleName `
         --yes 2>$null
     Write-Host "  Temporary firewall rule removed"
     } # end non-VNet-injected migrations block


### PR DESCRIPTION
## What changed

Five deployment blockers fixed across backend, infrastructure, and frontend.

### 1. Wrong startup binary — appCommandLine added (infra/modules/app-service.bicep)
The publish output contains two .runtimeconfig.json files (ours + BuildHost-netcore from Roslyn). Oryx picked the wrong one and fell back to hostingstart.dll.
Fix: Added appCommandLine: 'dotnet LegalDocSystem.API.dll' to siteConfig.

### 2. Malformed Key Vault URI — double-dot bug (infra/main.bicep, infra/main.json)
az.environment().suffixes.keyvaultDns already has a leading dot (.vault.azure.net). The previous template added another dot, producing '..vault.azure.net'. All KV references failed.
Fix: Removed the extra dot: 'https://\\/'

### 3. EF Core auto-migration on startup (backend/LegalDocSystem.API/Program.cs)
PostgreSQL uses VNet injection — unreachable from local machine. Added db.Database.Migrate() on App Service startup (App Service is VNet-integrated). Migrate() is idempotent.

### 4. Deploy script VNet detection + npm build fix (infra/scripts/deploy.ps1)
- Steps 5+6: detect VNet-injected PostgreSQL, skip local migration, delegate to Program.cs.
- Step 8: fix ErrorActionPreference around npm run build so Vite warnings don't kill the script.

### 5. SPA 404 on direct navigation (frontend/public/staticwebapp.config.json)
Added navigationFallback to rewrite all non-asset paths to /index.html for Azure SWA.

### New VNet module (infra/modules/vnet.bicep)
Extracted VNet provisioning with new/existing VNet path.

## Why it was changed
All five issues combined caused the production API to return 404/503 and the frontend to 404 on direct navigation.

## How to test
1. GET https://lawgate-prod-api-dztku2.azurewebsites.net/health -> 200 healthy
2. POST /api/auth/login (bad password) -> 401
3. Navigate directly to https://calm-field-02db0f300.7.azurestaticapps.net/login -> 200

## Verification (done in production)
- /health -> 200 healthy
- /api/auth/login (bad password) -> 401
- SWA /login direct navigation -> 200