### PR TITLE
Add performance indexes: documents, audit logs, users refresh token

### DIFF
--- a/backend/LegalDocSystem.Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/LegalDocSystem.Infrastructure/Data/ApplicationDbContext.cs
@@ -53,6 +53,9 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.Email).IsRequired().HasMaxLength(200);
             entity.Property(e => e.PasswordHash).IsRequired();
             entity.HasIndex(e => new { e.CompanyId, e.Email }).IsUnique();
+            entity.HasIndex(e => e.RefreshToken)
+                .HasDatabaseName("ix_users_refreshtoken")
+                .HasFilter("\"RefreshToken\" IS NOT NULL");
             
             // Relationships
             entity.HasMany(e => e.ProjectPermissions)
@@ -104,6 +107,7 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.ContentHash).HasMaxLength(100);
             entity.HasIndex(e => new { e.ProjectId, e.IsLatestVersion });
             entity.HasIndex(e => e.ParentDocumentId);
+            entity.HasIndex(e => new { e.ProjectId, e.Status }).HasDatabaseName("ix_documents_project_status");
             
             // Self-referencing relationship for versions
             entity.HasOne(e => e.ParentDocument)
@@ -129,6 +133,7 @@ public class ApplicationDbContext : DbContext
             entity.HasIndex(e => new { e.CompanyId, e.CreatedAt });
             entity.HasIndex(e => new { e.UserId, e.CreatedAt });
             entity.HasIndex(e => new { e.EntityType, e.EntityId });
+            entity.HasIndex(e => new { e.CompanyId, e.EntityType }).HasDatabaseName("ix_auditlogs_company_entity");
         });
     }
 

--- a/backend/LegalDocSystem.Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/LegalDocSystem.Infrastructure/Data/ApplicationDbContext.cs
@@ -133,7 +133,7 @@ public class ApplicationDbContext : DbContext
             entity.HasIndex(e => new { e.CompanyId, e.CreatedAt });
             entity.HasIndex(e => new { e.UserId, e.CreatedAt });
             entity.HasIndex(e => new { e.EntityType, e.EntityId });
-            entity.HasIndex(e => new { e.CompanyId, e.EntityType }).HasDatabaseName("ix_auditlogs_company_entity");
+            entity.HasIndex(e => new { e.CompanyId, e.EntityType, e.CreatedAt }).HasDatabaseName("ix_auditlogs_company_entity");
         });
     }
 

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.Designer.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.Designer.cs
@@ -87,7 +87,7 @@ namespace LegalDocSystem.Infrastructure.Migrations
 
                     b.HasIndex("CompanyId", "CreatedAt");
 
-                    b.HasIndex("CompanyId", "EntityType")
+                    b.HasIndex("CompanyId", "EntityType", "CreatedAt")
                         .HasDatabaseName("ix_auditlogs_company_entity");
 
                     b.HasIndex("EntityType", "EntityId");

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.Designer.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LegalDocSystem.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LegalDocSystem.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430123342_AddPerformanceIndexes")]
+    partial class AddPerformanceIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LegalDocSystem.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerformanceIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_users_refreshtoken",
+                table: "Users",
+                column: "RefreshToken",
+                filter: "\"RefreshToken\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documents_project_status",
+                table: "Documents",
+                columns: new[] { "ProjectId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_auditlogs_company_entity",
+                table: "AuditLogs",
+                columns: new[] { "CompanyId", "EntityType" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_users_refreshtoken",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "ix_documents_project_status",
+                table: "Documents");
+
+            migrationBuilder.DropIndex(
+                name: "ix_auditlogs_company_entity",
+                table: "AuditLogs");
+        }
+    }
+}

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
@@ -10,37 +10,37 @@ namespace LegalDocSystem.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateIndex(
-                name: "ix_users_refreshtoken",
-                table: "Users",
-                column: "RefreshToken",
-                filter: "\"RefreshToken\" IS NOT NULL");
+            migrationBuilder.Sql(
+                @"CREATE INDEX CONCURRENTLY ""ix_users_refreshtoken""
+                  ON ""Users"" (""RefreshToken"")
+                  WHERE ""RefreshToken"" IS NOT NULL;",
+                suppressTransaction: true);
 
-            migrationBuilder.CreateIndex(
-                name: "ix_documents_project_status",
-                table: "Documents",
-                columns: new[] { "ProjectId", "Status" });
+            migrationBuilder.Sql(
+                @"CREATE INDEX CONCURRENTLY ""ix_documents_project_status""
+                  ON ""Documents"" (""ProjectId"", ""Status"");",
+                suppressTransaction: true);
 
-            migrationBuilder.CreateIndex(
-                name: "ix_auditlogs_company_entity",
-                table: "AuditLogs",
-                columns: new[] { "CompanyId", "EntityType" });
+            migrationBuilder.Sql(
+                @"CREATE INDEX CONCURRENTLY ""ix_auditlogs_company_entity""
+                  ON ""AuditLogs"" (""CompanyId"", ""EntityType"");",
+                suppressTransaction: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "ix_users_refreshtoken",
-                table: "Users");
+            migrationBuilder.Sql(
+                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_users_refreshtoken"";",
+                suppressTransaction: true);
 
-            migrationBuilder.DropIndex(
-                name: "ix_documents_project_status",
-                table: "Documents");
+            migrationBuilder.Sql(
+                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_documents_project_status"";",
+                suppressTransaction: true);
 
-            migrationBuilder.DropIndex(
-                name: "ix_auditlogs_company_entity",
-                table: "AuditLogs");
+            migrationBuilder.Sql(
+                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_auditlogs_company_entity"";",
+                suppressTransaction: true);
         }
     }
 }

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
@@ -7,40 +7,33 @@ namespace LegalDocSystem.Infrastructure.Migrations
     /// <inheritdoc />
     public partial class AddPerformanceIndexes : Migration
     {
+        // CONCURRENTLY avoids an exclusive table lock during index build.
+        // EF Core must not wrap these statements in a transaction.
+        protected override bool SuppressTransaction => true;
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Filtered index: speeds up refresh-token lookups while ignoring logged-out users.
             migrationBuilder.Sql(
-                @"CREATE INDEX CONCURRENTLY ""ix_users_refreshtoken""
-                  ON ""Users"" (""RefreshToken"")
-                  WHERE ""RefreshToken"" IS NOT NULL;",
-                suppressTransaction: true);
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_users_refreshtoken" ON "Users" ("RefreshToken") WHERE "RefreshToken" IS NOT NULL;""");
 
+            // Composite index: covers the (ProjectId, Status) filter on the documents listing query.
             migrationBuilder.Sql(
-                @"CREATE INDEX CONCURRENTLY ""ix_documents_project_status""
-                  ON ""Documents"" (""ProjectId"", ""Status"");",
-                suppressTransaction: true);
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_documents_project_status" ON "Documents" ("ProjectId", "Status");""");
 
+            // Composite index: covers the audit-log filter AND the ORDER BY CreatedAt DESC so
+            // PostgreSQL can satisfy both the WHERE clause and the sort from a single index scan.
             migrationBuilder.Sql(
-                @"CREATE INDEX CONCURRENTLY ""ix_auditlogs_company_entity""
-                  ON ""AuditLogs"" (""CompanyId"", ""EntityType"");",
-                suppressTransaction: true);
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_auditlogs_company_entity" ON "AuditLogs" ("CompanyId", "EntityType", "CreatedAt" DESC);""");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(
-                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_users_refreshtoken"";",
-                suppressTransaction: true);
-
-            migrationBuilder.Sql(
-                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_documents_project_status"";",
-                suppressTransaction: true);
-
-            migrationBuilder.Sql(
-                @"DROP INDEX CONCURRENTLY IF EXISTS ""ix_auditlogs_company_entity"";",
-                suppressTransaction: true);
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_users_refreshtoken";""");
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_documents_project_status";""");
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_auditlogs_company_entity";""");
         }
     }
 }

--- a/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/20260430123342_AddPerformanceIndexes.cs
@@ -7,33 +7,35 @@ namespace LegalDocSystem.Infrastructure.Migrations
     /// <inheritdoc />
     public partial class AddPerformanceIndexes : Migration
     {
-        // CONCURRENTLY avoids an exclusive table lock during index build.
-        // EF Core must not wrap these statements in a transaction.
-        protected override bool SuppressTransaction => true;
-
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // CONCURRENTLY avoids an exclusive table lock during index build.
+            // suppressTransaction: true is required because CONCURRENTLY cannot run inside a transaction.
+
             // Filtered index: speeds up refresh-token lookups while ignoring logged-out users.
             migrationBuilder.Sql(
-                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_users_refreshtoken" ON "Users" ("RefreshToken") WHERE "RefreshToken" IS NOT NULL;""");
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_users_refreshtoken" ON "Users" ("RefreshToken") WHERE "RefreshToken" IS NOT NULL;""",
+                suppressTransaction: true);
 
             // Composite index: covers the (ProjectId, Status) filter on the documents listing query.
             migrationBuilder.Sql(
-                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_documents_project_status" ON "Documents" ("ProjectId", "Status");""");
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_documents_project_status" ON "Documents" ("ProjectId", "Status");""",
+                suppressTransaction: true);
 
             // Composite index: covers the audit-log filter AND the ORDER BY CreatedAt DESC so
             // PostgreSQL can satisfy both the WHERE clause and the sort from a single index scan.
             migrationBuilder.Sql(
-                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_auditlogs_company_entity" ON "AuditLogs" ("CompanyId", "EntityType", "CreatedAt" DESC);""");
+                """CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_auditlogs_company_entity" ON "AuditLogs" ("CompanyId", "EntityType", "CreatedAt" DESC);""",
+                suppressTransaction: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_users_refreshtoken";""");
-            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_documents_project_status";""");
-            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_auditlogs_company_entity";""");
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_users_refreshtoken";""", suppressTransaction: true);
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_documents_project_status";""", suppressTransaction: true);
+            migrationBuilder.Sql("""DROP INDEX CONCURRENTLY IF EXISTS "ix_auditlogs_company_entity";""", suppressTransaction: true);
         }
     }
 }

--- a/backend/LegalDocSystem.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/LegalDocSystem.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -84,7 +84,7 @@ namespace LegalDocSystem.Infrastructure.Migrations
 
                     b.HasIndex("CompanyId", "CreatedAt");
 
-                    b.HasIndex("CompanyId", "EntityType")
+                    b.HasIndex("CompanyId", "EntityType", "CreatedAt")
                         .HasDatabaseName("ix_auditlogs_company_entity");
 
                     b.HasIndex("EntityType", "EntityId");

--- a/docs/tracking/implementation-checklist.md
+++ b/docs/tracking/implementation-checklist.md
@@ -258,7 +258,7 @@ Add these in **GitHub → Settings → Secrets and variables → Actions → New
 - [x] Rate limiting configured — auth: 10/min, global: 100/min
 - [x] Security headers middleware active — CSP, X-Frame-Options, etc.
 - [ ] Custom domain configured (optional — add `CNAME` to your DNS after deployment)
-- [ ] Review and optimize database indexes (see notes below)
+- [x] Review and optimize database indexes — `AddPerformanceIndexes` migration added (ix_documents_project_status, ix_auditlogs_company_entity, ix_users_refreshtoken)
 - [ ] Load test the `/api/documents/upload-url` and `/api/auth/login` endpoints before launch
 
 ### Database Index Review


### PR DESCRIPTION
Adds EF Core migration `AddPerformanceIndexes` with three targeted indexes:

- `ix_documents_project_status` — composite on Documents(ProjectId, Status)
- `ix_auditlogs_company_entity` — composite on AuditLogs(CompanyId, EntityType)
- `ix_users_refreshtoken` — filtered on Users(RefreshToken) WHERE IS NOT NULL

## How to test
1. `dotnet ef database update` from the Infrastructure project
2. Verify with `SELECT indexname FROM pg_indexes WHERE indexname LIKE 'ix_%';`
3. `dotnet test` — all tests should pass