### PR TITLE
Fix transient DB failures and blocking email sends on registration

### DIFF
--- a/backend/LegalDocSystem.API/Program.cs
+++ b/backend/LegalDocSystem.API/Program.cs
@@ -45,7 +45,11 @@ builder.Services.AddMemoryCache();
 // Configure Database
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseNpgsql(connectionString));
+    options.UseNpgsql(connectionString, npgsqlOptions =>
+        npgsqlOptions.EnableRetryOnFailure(
+            maxRetryCount: 3,
+            maxRetryDelay: TimeSpan.FromSeconds(5),
+            errorCodesToAdd: null)));
 
 // Register Services
 builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();

--- a/backend/LegalDocSystem.Infrastructure/Services/AuthService.cs
+++ b/backend/LegalDocSystem.Infrastructure/Services/AuthService.cs
@@ -141,16 +141,17 @@ public class AuthService : IAuthService
             user.RefreshTokenExpiry = refreshTokenExpiry;
             await _context.SaveChangesAsync();
 
-            // Send verification email (non-blocking — failure should not abort registration)
-            try
+            // Send verification email (fire-and-forget — must not block the registration response)
+            var verificationLink = $"{_frontendBaseUrl}/verify-email?token={Uri.EscapeDataString(rawVerificationToken)}";
+            var registrationEmail = user.Email;
+            var registrationFirstName = user.FirstName;
+            var emailService = _emailService;
+            var logger = _logger;
+            _ = Task.Run(async () =>
             {
-                var verificationLink = $"{_frontendBaseUrl}/verify-email?token={Uri.EscapeDataString(rawVerificationToken)}";
-                await _emailService.SendEmailVerificationAsync(user.Email, user.FirstName, verificationLink);
-            }
-            catch (Exception emailEx)
-            {
-                _logger.LogError(emailEx, "Failed to send verification email to {Email}", user.Email);
-            }
+                try { await emailService.SendEmailVerificationAsync(registrationEmail, registrationFirstName, verificationLink); }
+                catch (Exception emailEx) { logger.LogError(emailEx, "Failed to send verification email to {Email}", registrationEmail); }
+            });
 
             return new TokenResponseDto
             {
@@ -335,15 +336,16 @@ public class AuthService : IAuthService
         user.ResetTokenExpiry = DateTime.UtcNow.AddHours(1);
         await _context.SaveChangesAsync();
 
-        try
+        var resetLink = $"{_frontendBaseUrl}/reset-password?token={Uri.EscapeDataString(rawToken)}";
+        var resetEmail = user.Email;
+        var resetFirstName = user.FirstName;
+        var resetEmailService = _emailService;
+        var resetLogger = _logger;
+        _ = Task.Run(async () =>
         {
-            var resetLink = $"{_frontendBaseUrl}/reset-password?token={Uri.EscapeDataString(rawToken)}";
-            await _emailService.SendPasswordResetEmailAsync(user.Email, user.FirstName, resetLink);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to send password reset email to {Email}", email);
-        }
+            try { await resetEmailService.SendPasswordResetEmailAsync(resetEmail, resetFirstName, resetLink); }
+            catch (Exception ex) { resetLogger.LogError(ex, "Failed to send password reset email to {Email}", resetEmail); }
+        });
     }
 
     public async Task<bool> ResetPasswordAsync(string token, string newPassword)
@@ -406,15 +408,16 @@ public class AuthService : IAuthService
         user.EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(24);
         await _context.SaveChangesAsync();
 
-        try
+        var verificationLink = $"{_frontendBaseUrl}/verify-email?token={Uri.EscapeDataString(rawToken)}";
+        var resendEmail = user.Email;
+        var resendFirstName = user.FirstName;
+        var resendEmailService = _emailService;
+        var resendLogger = _logger;
+        _ = Task.Run(async () =>
         {
-            var verificationLink = $"{_frontendBaseUrl}/verify-email?token={Uri.EscapeDataString(rawToken)}";
-            await _emailService.SendEmailVerificationAsync(user.Email, user.FirstName, verificationLink);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to resend verification email to {Email}", email);
-        }
+            try { await resendEmailService.SendEmailVerificationAsync(resendEmail, resendFirstName, verificationLink); }
+            catch (Exception ex) { resendLogger.LogError(ex, "Failed to resend verification email to {Email}", resendEmail); }
+        });
     }
 
     public async Task<bool> ValidateTokenAsync(string token)

--- a/backend/LegalDocSystem.UnitTests/Services/AuthServiceTests.cs
+++ b/backend/LegalDocSystem.UnitTests/Services/AuthServiceTests.cs
@@ -183,6 +183,7 @@ public class AuthServiceTests : IDisposable
     {
         // Act
         await _sut.RegisterAsync(ValidRegisterDto());
+        await Task.Delay(200); // allow fire-and-forget Task.Run to complete
 
         // Assert
         await _emailService.Received(1)
@@ -543,6 +544,7 @@ public class AuthServiceTests : IDisposable
 
         // Act
         await _sut.ResendVerificationEmailAsync("owner@test.com");
+        await Task.Delay(200); // allow fire-and-forget Task.Run to complete
 
         // Assert
         await _emailService.Received(1)

--- a/backend/LegalDocSystem.UnitTests/Services/AuthServiceTests.cs
+++ b/backend/LegalDocSystem.UnitTests/Services/AuthServiceTests.cs
@@ -370,6 +370,7 @@ public class AuthServiceTests : IDisposable
 
         // Act
         await _sut.ForgotPasswordAsync("owner@test.com");
+        await Task.Delay(200); // allow fire-and-forget Task.Run to complete
 
         // Assert
         await _emailService.Received(1)


### PR DESCRIPTION
## What changed

### 1. EF Core retry policy for transient PostgreSQL failures (Program.cs)
Added `EnableRetryOnFailure` to the Npgsql configuration:
- Max 3 retries, up to 5 second delay between attempts
- Handles "An exception has been raised that is likely due to a transient failure" automatically instead of returning a 500

### 2. Email sending is now fire-and-forget (AuthService.cs)
All three email call sites were awaited inline, blocking the response for 6–11 seconds (observed in production logs 03 May 2026):
- RegisterAsync — ~6 sec added to registration response
- ForgotPasswordAsync — reset email awaited
- ResendVerificationEmailAsync — verification email awaited

All three are now Task.Run fire-and-forget. DB writes (token generation, SaveChangesAsync) all complete before the fire-and-forget starts — no data-consistency risk. Errors are still logged at [ERR] level.

## Why
- User reported transient failure exception on registration
- Production logs showed /api/auth/register taking 12,422ms due to awaited ACS email call
- No retry policy meant any transient DB hiccup caused an immediate 500

## How to test
1. Register a new account — should respond in ~1–2 sec instead of ~12 sec
2. Verification email should still arrive
3. Infrastructure note: App__FrontendBaseUrl was set on the App Service directly to fix localhost links in emails